### PR TITLE
Fix acceptance tests

### DIFF
--- a/statuscake/provider_test.go
+++ b/statuscake/provider_test.go
@@ -35,4 +35,7 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("STATUSCAKE_APIKEY"); v == "" {
 		t.Fatal("STATUSCAKE_APIKEY must be set for acceptance tests")
 	}
+	if v := os.Getenv("STATUSCAKE_TEST_CONTACT_GROUP_ID"); v == "" {
+		t.Fatal("STATUSCAKE_TEST_CONTACT_GROUP_ID must be set for acceptance tests")
+	}
 }


### PR DESCRIPTION
This was making the acceptance test to fail since it was using the hardcoded contact group in the code which doesn't exist any other account except for the initial developer.

https://github.com/ndench/terraform-provider-statuscake/commit/4efdab4181cd2bfd243600def27f70f0580942a3#diff-74acd2515ee5ecd44424d7a31439989eR221

This change now explicitly prompts the user to include the contact group